### PR TITLE
add variable azure_client_id for the msi api call

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ $ gem install fluent-plugin-azurestorage-gen2
   azure_storage_account            mystorageabfs
   azure_container                  mycontainer
   azure_instance_msi               /subscriptions/mysubscriptionid
+  azure_client_id                  <msi client id>
   azure_object_key_format          %{path}-%{index}.%{file_extension}
   azure_oauth_refresh_interval     3600
   time_slice_format                %Y%m%d-%H
@@ -91,6 +92,10 @@ Your Azure Storage Access Key(Primary or Secondary). This also can be got from A
 ### azure_instance_msi
 
 Your Azure Managed Service Identity ID. When storage key authentication is not used, the plugin uses OAuth2 to authenticate as given MSI. This authentication method only works on Azure VM. If the VM has only one MSI assigned, this parameter becomes optional and the only MSI will be used. Otherwise this parameter is required.
+
+### azure_client_id
+
+Your Azure Managed Service Identity client ID. this is required in combination of azure_instance_msi.
 
 ### azure_oauth_tenant_id (Preview)
 

--- a/lib/fluent/plugin/out_azurestorage_gen2.rb
+++ b/lib/fluent/plugin/out_azurestorage_gen2.rb
@@ -24,6 +24,7 @@ module Fluent::Plugin
         config_param :azure_storage_account, :string, :default => nil
         config_param :azure_storage_access_key, :string, :default => nil, :secret => true
         config_param :azure_instance_msi, :string, :default => nil
+        config_param :azure_client_id, :string, :default => nil
         config_param :azure_oauth_app_id, :string, :default => nil, :secret => true
         config_param :azure_oauth_secret, :string, :default => nil, :secret => true
         config_param :azure_oauth_tenant_id, :string, :default => nil
@@ -58,7 +59,7 @@ module Fluent::Plugin
         config_section :format do
             config_set_default :@type, DEFAULT_FORMAT_TYPE
         end
-  
+
         config_section :buffer do
             config_set_default :chunk_keys, ['time']
             config_set_default :timekey, (60 * 60 * 24)
@@ -81,7 +82,7 @@ module Fluent::Plugin
             end
 
             @formatter = formatter_create
-      
+
             if @azure_container.nil?
               raise Fluent::ConfigError, "azure_container is needed"
             end
@@ -275,6 +276,7 @@ module Fluent::Plugin
             params = { :"api-version" => ACCESS_TOKEN_API_VERSION, :resource => "#{@url_storage_resource}" }
             unless @azure_instance_msi.nil?
                 params[:msi_res_id] = @azure_instance_msi
+                params[:client_id] = @azure_client_id
             end
             req_opts = {
                 :params => params,


### PR DESCRIPTION
current version does not work with MSI.
when calling the api to get the token you need `msi_res_id` and `client_id` in order to get the token