### PR TITLE
Use bool instead of string for `azure_use_workload_id`

### DIFF
--- a/lib/fluent/plugin/out_azurestorage_gen2.rb
+++ b/lib/fluent/plugin/out_azurestorage_gen2.rb
@@ -23,7 +23,7 @@ module Fluent::Plugin
         config_param :path, :string, :default => ""
         config_param :azure_storage_account, :string, :default => nil
         config_param :azure_storage_access_key, :string, :default => nil, :secret => true
-        config_param :azure_use_workload_id, :string, :default => false
+        config_param :azure_use_workload_id, :bool, :default => false
         config_param :azure_federated_token_file_path, :string, :default => nil
         config_param :azure_instance_msi, :string, :default => nil
         config_param :azure_client_id, :string, :default => nil


### PR DESCRIPTION
Fixes issue I introduced in #23 where it's impossible to provide a falsy value for `azure_use_workload_id` - it's false if you leave it unpopulated, but if you, like me, have something like 
`azure_use_workload_id            "#{ENV['USE_WORKLOAD_ID']}"`
then it's not possible to set a value that isn't truthy